### PR TITLE
Added fix for issue 28 -- accept invalid certs

### DIFF
--- a/Public/Http.ps1
+++ b/Public/Http.ps1
@@ -33,7 +33,18 @@ function Http {
         [Parameter(Mandatory, Position=3)]
         [scriptblock]$Should
     )    
-    
+    add-type -TypeDefinition  @"
+        using System.Net;
+        using System.Security.Cryptography.X509Certificates;
+        public class TrustAllCertsPolicy : ICertificatePolicy {
+            public bool CheckValidationResult(
+                ServicePoint srvPoint, X509Certificate certificate,
+                WebRequest request, int certificateProblem) {
+                return true;
+            }
+        }
+"@
+    [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
     $params = Get-PoshspecParam -TestName Http -TestExpression {Invoke-WebRequest -Uri '$Target' -UseBasicParsing -ErrorAction SilentlyContinue} @PSBoundParameters
     
     Invoke-PoshspecExpression @params


### PR DESCRIPTION
I believe the solution is to add:
# Added for dealing with invalid certificates.

add-type -TypeDefinition  @"
using System.Net;
using System.Security.Cryptography.X509Certificates;
public class TrustAllCertsPolicy : ICertificatePolicy {
public bool CheckValidationResult(
ServicePoint srvPoint, X509Certificate certificate,
WebRequest request, int certificateProblem) {
return true;
}
}
"@
[System.Net.ServicePointManager]::CertificatePolicy = New-Object
TrustAllCertsPolicy

to the http.ps1 file.
