### PR TITLE
Fix so SoftwareProduct can detect 32-bit only products

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -143,7 +143,7 @@ Task Test -depends Build {
 }
 
 Task Build -depends Clean -requiredVariables PublishDir, Exclude, ModuleName {
-    if ((Get-Command -Name Step-ModuleVersion).Source)
+    if ((Get-Command -Name Step-ModuleVersion -ErrorAction SilentlyContinue).Source)
     {
         Step-ModuleVersion -Path $ManifestPath
     }

--- a/Public/SoftwareProduct.ps1
+++ b/Public/SoftwareProduct.ps1
@@ -36,7 +36,7 @@ function SoftwareProduct {
         [scriptblock]$Should
     )
     
-    $expression = {Get-ItemProperty -Path hklm:\\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object DisplayName -Match '$Target'}
+    $expression = {@('HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\\Software\Microsoft\Windows\CurrentVersion\Uninstall\*') | Where-Object { Test-Path $_ } | Get-ItemProperty | Where-Object DisplayName -Match '$Target'}
     
     $params = Get-PoshspecParam -TestName SoftwareProduct -TestExpression $expression @PSBoundParameters
     

--- a/Tests/poshspec.Tests.ps1
+++ b/Tests/poshspec.Tests.ps1
@@ -362,7 +362,7 @@ Describe 'Test Functions' {
             }
 
             It "Should return the correct test Expression" {
-                $results.Expression | Should Be "Get-ItemProperty -Path hklm:\\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object DisplayName -Match 'Microsoft .NET Framework 4.6.1' | Should Exist"
+                $results.Expression | Should Be "@('HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\\Software\Microsoft\Windows\CurrentVersion\Uninstall\*') | Where-Object { Test-Path $_ } | Get-ItemProperty | Where-Object DisplayName -Match 'Microsoft .NET Framework 4.6.1' | Should Exist"
             }
         }
         
@@ -375,7 +375,7 @@ Describe 'Test Functions' {
             }
 
             It "Should return the correct test Expression" {
-                $results.Expression | Should Be "Get-ItemProperty -Path hklm:\\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object DisplayName -Match 'Microsoft .NET Framework 4.6.1' | Select-Object -ExpandProperty 'DisplayVersion' | Should Be 4.6.01055"
+                $results.Expression | Should Be "@('HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\\Software\Microsoft\Windows\CurrentVersion\Uninstall\*') | Where-Object { Test-Path $_ } | Get-ItemProperty | Where-Object DisplayName -Match 'Microsoft .NET Framework 4.6.1' | Select-Object -ExpandProperty 'DisplayVersion' | Should Be 4.6.01055"
             }
         }
 


### PR DESCRIPTION
Added registry entry that needs to be checked for 32-bit products that are installed on a 64-bit system.