### PR TITLE
Master

### DIFF
--- a/Private/Get-PoshSpecADGroup.ps1
+++ b/Private/Get-PoshSpecADGroup.ps1
@@ -37,22 +37,17 @@ function Get-PoshSpecADGroup {
         }
     }
 
-    $groups = SearchAd -Name $Name
-    foreach ($group in $groups) 
+    $groups = SearchAd -Name $Name -ObjectType 'Group'
+    foreach ($g in $groups) 
     {   
-        $type = (([hashtable]$group.Properties).getenumerator() | where {$_.Key -eq 'groupType'}).value
+        $group = [adsi]$g.path
+        $groupType = [string]$group.groupType
+
         [pscustomobject]@{
-            SamAccountName  = $group.sAMAccountName
-            Name            = $group.name
-            Scope           = $groupTypes[$type].Scope
-            Type            = $groupTypes[$type].Type
+            SamAccountName  = [string]$group.sAMAccountName
+            Name            = [string]$group.name
+            Scope           = $groupTypes[[int]$groupType].Scope
+            Type            = $groupTypes[[int]$groupType].Type
         }
     }
-}
-
-function SearchAd {
-    param($Name)
-
-    $searcher = [adsisearcher]"(&(objectClass=group)(objectCategory=group)(name=$Name))"
-    $searcher.FindAll()
 }

--- a/Private/Get-PoshSpecADGroup.ps1
+++ b/Private/Get-PoshSpecADGroup.ps1
@@ -1,0 +1,58 @@
+function Get-PoshSpecADGroup {
+    [CmdletBinding()]
+    param( 
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name
+    )
+
+    $groupTypes = @{
+        -2147483646 = @{
+            Scope = 'Global'
+            Type = 'Security'
+        }
+        -2147483644 = @{
+            Scope = 'DomainLocal'
+            Type = 'Security'
+        }
+        -2147483643 = @{
+            Scope = 'Global'
+            Type = 'Security'
+        }
+        -2147483640 = @{
+            Scope = 'Universal'
+            Type = 'Security'
+        }
+        2 = @{
+            Scope = 'Global'
+            Type = 'Distribution'
+        }
+        4 = @{
+            Scope = 'DomainLocal'
+            Type = 'Distribution'
+        }
+        8 = @{
+            Scope = 'Universal'
+            Type = 'Distribution'
+        }
+    }
+
+    $groups = SearchAd -Name $Name
+    foreach ($group in $groups) 
+    {   
+        $type = (([hashtable]$group.Properties).getenumerator() | where {$_.Key -eq 'groupType'}).value
+        [pscustomobject]@{
+            SamAccountName  = $group.sAMAccountName
+            Name            = $group.name
+            Scope           = $groupTypes[$type].Scope
+            Type            = $groupTypes[$type].Type
+        }
+    }
+}
+
+function SearchAd {
+    param($Name)
+
+    $searcher = [adsisearcher]"(&(objectClass=group)(objectCategory=group)(name=$Name))"
+    $searcher.FindAll()
+}

--- a/Private/Get-PoshSpecADOrganizationalUnit.ps1
+++ b/Private/Get-PoshSpecADOrganizationalUnit.ps1
@@ -1,0 +1,25 @@
+function Get-PoshSpecADOrganizationalUnit {
+    [CmdletBinding()]
+    param( 
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name
+    )
+
+    $ous = SearchAd -Name $Name
+    foreach ($o in $ous) 
+    {   
+        $ou = ([hashtable]$o.Properties).getenumerator()
+        [pscustomobject]@{
+            Name  = [string]($ou | where {$_.Key -eq 'ou'}).value
+            Path  = $o.Path.TrimStart('LDAP://')
+        }
+    }
+}
+
+function SearchAd {
+    param($Name)
+
+    $searcher = [adsisearcher]"(&(objectClass=organizationalUnit)(name=$Name))"
+    $searcher.FindAll()
+}

--- a/Private/Get-PoshSpecADOrganizationalUnit.ps1
+++ b/Private/Get-PoshSpecADOrganizationalUnit.ps1
@@ -6,7 +6,7 @@ function Get-PoshSpecADOrganizationalUnit {
         [string]$Name
     )
 
-    $ous = SearchAd -Name $Name
+    $ous = SearchAd -Name $Name -ObjectType 'OrganizationalUnit'
     foreach ($o in $ous) 
     {   
         $ou = ([hashtable]$o.Properties).getenumerator()
@@ -15,11 +15,4 @@ function Get-PoshSpecADOrganizationalUnit {
             Path  = $o.Path.TrimStart('LDAP://')
         }
     }
-}
-
-function SearchAd {
-    param($Name)
-
-    $searcher = [adsisearcher]"(&(objectClass=organizationalUnit)(name=$Name))"
-    $searcher.FindAll()
 }

--- a/Private/Get-PoshSpecADUser.ps1
+++ b/Private/Get-PoshSpecADUser.ps1
@@ -1,0 +1,34 @@
+function Get-PoshSpecADUser {
+    [CmdletBinding()]
+    param( 
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name
+    )
+
+    $ACCOUNTDISABLE       = 0x000002
+    $DONT_EXPIRE_PASSWORD = 0x010000
+    $PASSWORD_EXPIRED     = 0x800000
+    
+    $users = SearchAd -Name $Name
+    foreach ($user in $users) 
+    {   
+        [pscustomobject]@{
+            SamAccountName       = $user.sAMAccountName
+            Name                 = $user.name
+            GivenName            = $user.givenName
+            SurName              = $user.surName
+            Mail                 = $user.mail
+            Enabled              = -not [bool]($user.userAccountControl -band $ACCOUNTDISABLE)
+            PasswordNeverExpires = [bool]($user.userAccountControl -band $DONT_EXPIRE_PASSWORD)
+            PasswordExpired      = [bool]($user.userAccountControl -band $PASSWORD_EXPIRED)
+        }
+    }
+}
+
+function SearchAd {
+    param($Name)
+
+    $searcher = [adsisearcher]"(&(objectClass=user)(objectCategory=person)(Name=$Name))"
+    $searcher.FindAll()
+}

--- a/Private/Get-PoshspecParam.ps1
+++ b/Private/Get-PoshspecParam.ps1
@@ -19,9 +19,9 @@ function Get-PoshspecParam {
         [Parameter()]
         [string]
         $Qualifier,                   
-        [Parameter(Mandatory)]
+        [Parameter()]
         [scriptblock]
-        $Should
+        $Should = { Should Exist }
     )
     
     $assertion = $Should.ToString().Trim()
@@ -53,7 +53,17 @@ function Get-PoshspecParam {
 
     $expressionString = $ExecutionContext.InvokeCommand.ExpandString($expressionString)
     
-    $expressionString += " | $assertion"
+    switch ($assertion) {
+        'Should Exist' {
+            $expressionString += " | should not benullorempty"
+        }
+        'Should Not Exist' {
+            $expressionString += " | should benullorempty"
+        }
+        Default {
+            $expressionString += " | $assertion"
+        }
+    }
     
     Write-Output -InputObject ([PSCustomObject]@{Name = $nameString; Expression = $expressionString})
 }

--- a/Private/Invoke-PoshspecExpression.ps1
+++ b/Private/Invoke-PoshspecExpression.ps1
@@ -8,6 +8,7 @@ function Invoke-PoshspecExpression {
         $InputObject
     )
     
+    Write-Verbose -Message "Invoking 'it' block with expression: $($InputObject.Expression)"
     It $InputObject.Name {
         Invoke-Expression $InputObject.Expression
     }    

--- a/Private/SearchAd.ps1
+++ b/Private/SearchAd.ps1
@@ -1,0 +1,27 @@
+function SearchAd {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+        
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [ValidateSet('User','Group','OrganizationalUnit')]
+        [string]$ObjectType
+    )
+
+    $searchString = switch ($ObjectType) {
+        'Group' {
+            "(&(objectClass=group)(objectCategory=group)(name=$Name))"
+        }
+        'User' {
+            "(&(objectClass=person)(name=$Name))"
+        }
+        'OrganizationalUnit' {
+            "(&(objectClass=organizationalUnit)(name=$Name))"
+        }
+        Default {}
+    }
+    $searcher = [adsisearcher]$searchString
+    $searcher.FindAll()
+}

--- a/Public/ADGroup.ps1
+++ b/Public/ADGroup.ps1
@@ -1,0 +1,38 @@
+<#
+.SYNOPSIS
+    Test an Active Directory group.
+.DESCRIPTION
+    Tests multiple attributes associated with an Active Directory group.
+.PARAMETER Target
+    Specifies the samAccountNames of one or more Active Directory groups.
+.PARAMETER Should 
+    A Script Block defining a Pester Assertion.   
+.EXAMPLE
+    ADGroup GroupOne Scope { Should be 'DomainLocal' }
+.EXAMPLE
+    ADGroup jschmoe Category { Should be 'Security' }
+#>
+function ADGroup {
+    [CmdletBinding(DefaultParameterSetName='prop')]
+    param( 
+        [Parameter(Mandatory, Position=1)]
+        [Alias("Name")]
+        [string]$Target,
+
+        [Parameter(Position=2, ParameterSetName='prop')]
+        [ValidateSet('Scope','Category')]
+        [string]$Property,
+
+        [Parameter(Position=2, ParameterSetName='noprop')]
+        [Parameter(Position=3, ParameterSetName='prop')]
+        [scriptblock]$Should
+    )
+
+    $testExpression = {
+        Get-PoshSpecADGroup -Name '$Target'
+    }
+
+    $params = Get-PoshspecParam -TestName ADGroup -TestExpression $testExpression @PSBoundParameters
+    
+    Invoke-PoshspecExpression @params
+}

--- a/Public/ADOrganizationalUnit.ps1
+++ b/Public/ADOrganizationalUnit.ps1
@@ -1,0 +1,32 @@
+<#
+.SYNOPSIS
+    Test an Active Directory organizational unit.
+.DESCRIPTION
+    Tests multiple attributes associated with an Active Directory organizational unit.
+.PARAMETER Target
+    Specifies the samAccountNames of one or more Active Directory organizational units.
+.PARAMETER Should 
+    A Script Block defining a Pester Assertion.
+.EXAMPLE
+    ADOrganizationalUnit Computers
+#>
+function ADOrganizationalUnit {
+    [CmdletBinding(DefaultParameterSetName='prop')]
+    param( 
+        [Parameter(Mandatory, Position=1)]
+        [Alias("Name")]
+        [string]$Target,
+
+        [Parameter(Position=2, ParameterSetName='noprop')]
+        [Parameter(Position=3, ParameterSetName='prop')]
+        [scriptblock]$Should
+    )
+
+    $testExpression = {
+        Get-PoshSpecADOrganizationalUnit -Name '$Target'
+    }
+
+    $params = Get-PoshspecParam -TestName ADOrganizationalUnit -TestExpression $testExpression @PSBoundParameters
+    
+    Invoke-PoshspecExpression @params
+}

--- a/Public/ADUser.ps1
+++ b/Public/ADUser.ps1
@@ -1,0 +1,38 @@
+<#
+.SYNOPSIS
+    Test an Active Directory user.
+.DESCRIPTION
+    Tests multiple attributes associated with an Active Directory user.
+.PARAMETER Target
+    Specifies the samAccountNames of one or more Active Directory users.
+.PARAMETER Should 
+    A Script Block defining a Pester Assertion.   
+.EXAMPLE
+    ADUser jschmoe Enabled { Should be $true }
+.EXAMPLE
+    ADUser jschmoe GivenName { Should be 'Joe' }
+#>
+function ADUser {
+    [CmdletBinding(DefaultParameterSetName='prop')]
+    param( 
+        [Parameter(Mandatory, Position=1)]
+        [Alias("UserName")]
+        [string]$Target,
+
+        [Parameter(Position=2, ParameterSetName='prop')]
+        [ValidateSet('Enabled','GivenName','SurName')]
+        [string]$Property,
+
+        [Parameter(Position=2, ParameterSetName='noprop')]
+        [Parameter(Position=3, ParameterSetName='prop')]
+        [scriptblock]$Should
+    )
+
+    $testExpression = {
+        Get-PoshSpecADUser -Name '$Target'
+    }
+
+    $params = Get-PoshspecParam -TestName ADUser -TestExpression $testExpression @PSBoundParameters
+    
+    Invoke-PoshspecExpression @params
+}

--- a/Public/ADUser.ps1
+++ b/Public/ADUser.ps1
@@ -20,7 +20,7 @@ function ADUser {
         [string]$Target,
 
         [Parameter(Position=2, ParameterSetName='prop')]
-        [ValidateSet('Enabled','GivenName','SurName')]
+        [ValidateSet('Enabled','GivenName','SurName','Department','OrganizationalUnit')]
         [string]$Property,
 
         [Parameter(Position=2, ParameterSetName='noprop')]

--- a/Public/File.ps1
+++ b/Public/File.ps1
@@ -26,7 +26,11 @@
     )
  
     $name = Split-Path -Path $Target -Leaf
-    $params = Get-PoshspecParam -TestName File -TestExpression {'$Target'} -FriendlyName $name @PSBoundParameters
+
+    $expression = {
+        Get-Item -Path '$Target' -ErrorAction SilentlyContinue
+    }
+    $params = Get-PoshspecParam -TestName File -TestExpression $expression -FriendlyName $name @PSBoundParameters
     
     Invoke-PoshspecExpression @params
 }

--- a/Public/Folder.ps1
+++ b/Public/Folder.ps1
@@ -26,7 +26,7 @@ function Folder {
     )
     
 
-    $params = Get-PoshspecParam -TestName Folder -TestExpression {'$Target'} @PSBoundParameters
+    $params = Get-PoshspecParam -TestName Folder -TestExpression {Get-Item -Path '$Target' -ErrorAction SilentlyContinue } @PSBoundParameters
     
     Invoke-PoshspecExpression @params
 }

--- a/Public/Registry.ps1
+++ b/Public/Registry.ps1
@@ -43,7 +43,7 @@ function Registry {
     }
     else 
     {
-        $expression = {'$Target'}
+        $expression = {Get-Item -Path '$Target' -ErrorAction SilentlyContinue }
     }
     
     $params = Get-PoshspecParam -TestName Registry -TestExpression $expression -FriendlyName $name @PSBoundParameters

--- a/Tests/poshspec.Tests.ps1
+++ b/Tests/poshspec.Tests.ps1
@@ -1,4 +1,6 @@
 $ModuleManifestName = 'poshspec.psd1'
+
+Get-Module -Name 'PoshSpec' -All | Remove-Module
 Import-Module $PSScriptRoot\..\$ModuleManifestName
 
 Describe 'Module Manifest Tests' {
@@ -18,7 +20,7 @@ Describe 'Get-PoshspecParam' {
             }
 
             It "Should return the correct test Expression" {
-                $results.Expression | Should Be "Get-Item 'name' | Should Exist"
+                $results.Expression | Should Be "Get-Item 'name' | should not benullorempty"
             }            
         }
         
@@ -30,7 +32,7 @@ Describe 'Get-PoshspecParam' {
             }
 
             It "Should return the correct test Expression" {
-                $results.Expression | Should Be "Get-Item 'Spaced Value' | Should Exist"
+                $results.Expression | Should Be "Get-Item 'Spaced Value' | should not benullorempty"
             }            
         }        
         
@@ -42,7 +44,7 @@ Describe 'Get-PoshspecParam' {
             }
 
             It "Should return the correct test Expression" {
-                $results.Expression | Should Be "Get-Item 'name' 'Something' | Select-Object -ExpandProperty 'Something' | Should Exist"
+                $results.Expression | Should Be "Get-Item 'name' 'Something' | Select-Object -ExpandProperty 'Something' | should not benullorempty"
             }                
         }
         
@@ -54,10 +56,216 @@ Describe 'Get-PoshspecParam' {
             }
 
             It "Should return the correct test Expression" {
-                $results.Expression | Should Be "Get-Item 'name' 'Something' '1' | Select-Object -ExpandProperty 'Something' | Should Exist"
+                $results.Expression | Should Be "Get-Item 'name' 'Something' '1' | Select-Object -ExpandProperty 'Something' | should not benullorempty"
             }            
         }        
     }    
+}
+
+Describe 'Get-PoshSpecADOrganizatinalUnit' {
+    InModuleScope PoshSpec {
+
+        context 'OU Exists' {
+
+            mock 'SearchAd' {
+                [pscustomobject]@{
+                    Path = 'LDAP://ou1,DC=lab,DC=local'
+                    Properties = @{
+                        ou = 'ou1'
+                    }
+                }
+            }
+
+            $results = Get-PoshSpecADOrganizationalUnit -Name 'DoesExist'
+
+            it 'should return a single pscustomobject' {
+                @($results).Count | should be 1
+            }
+
+            it 'should return the expected name' {
+                $results.Name | should be 'ou1'
+            }
+
+            it 'should return the expected path' {
+                $results.Path | should be 'ou1,DC=lab,DC=local'
+            }
+
+        }
+
+        context 'OU does not exist' {
+            
+            mock 'SearchAd'
+
+            $results = Get-PoshSpecADOrganizationalUnit -Name 'DoesNotExist'
+
+            it 'should return nothing' {
+                $results | should BeNullOrEmpty
+            }
+
+        }
+    }
+}
+
+Describe 'Get-PoshSpecADGroup' {
+    InModuleScope PoshSpec {
+
+        context 'Group Exists' {
+
+             $testCases = @(
+                @{
+                    GroupTypeNumber = -2147483646
+                    ExpectedScope = 'Global'
+                    ExpectedType = 'Security'
+                }
+                @{
+                    GroupTypeNumber = -2147483644
+                    ExpectedScope = 'DomainLocal'
+                    ExpectedType = 'Security'
+                }
+                @{
+                    GroupTypeNumber = -2147483643
+                    ExpectedScope = 'Global'
+                    ExpectedType = 'Security'
+                }
+                @{
+                    GroupTypeNumber = -2147483640
+                    ExpectedScope = 'Universal'
+                    ExpectedType = 'Security'
+                }
+                @{
+                    GroupTypeNumber = 2
+                    ExpectedScope = 'Global'
+                    ExpectedType = 'Distribution'
+                }
+                @{
+                    GroupTypeNumber = 4
+                    ExpectedScope = 'DomainLocal'
+                    ExpectedType = 'Distribution'
+                }
+                @{
+                    GroupTypeNumber = 8
+                    ExpectedScope = 'Universal'
+                    ExpectedType = 'Distribution'
+                }
+            )
+
+            foreach ($case in $testCases) {
+
+                mock 'SearchAd' {
+                    [pscustomobject]@{
+                        samAccountName = 'samAccountName'
+                        name = 'name'
+                        Properties = @{
+                            groupType = $case.GroupTypeNumber
+                        }
+                    }
+                }
+
+                $results = Get-PoshSpecADGroup -Name 'DoesExist'
+
+                it "when the group type number is $($case.GroupTypeNumber) it should return a single pscustomobject" {
+                    @($results).Count | should be 1
+                }
+
+                it "when the group type number is $($case.GroupTypeNumber) it should return the expected samAccountName" {
+                    $results.SamAccountName | should be 'samAccountName'
+                }
+
+                it "when the group type number is $($case.GroupTypeNumber) it should return the expected name" {
+                    $results.Name | should be 'name'
+                }
+
+                it "when the group type number is $($case.GroupTypeNumber) it should return the scope of $($case.ExpectedScope)" {
+                    
+                    $results.Scope | should be $case.ExpectedScope
+                }
+
+                it "when the group type number is $($case.GroupTypeNumber) it should return the type of $($case.ExpectedType)" {
+
+                    $results.Type | should be $case.ExpectedType
+                    
+                }
+            }
+        }
+
+        context 'Group does not exist' {
+            
+            mock 'SearchAd'
+
+            $results = Get-PoshSpecADGroup -Name 'DoesNotExist'
+
+            it 'should return nothing' {
+                $results | should BeNullOrEmpty
+            }
+
+        }
+    }
+}
+
+Describe 'Get-PoshSpecADUser' {
+    InModuleScope PoshSpec {
+
+        context 'User Exists' {
+
+            mock 'SearchAd' {
+                [pscustomobject]@{
+                    samAccountName = 'samaccountnamehere'
+                    name = 'namehere'
+                    givenName = 'givenNameHere'
+                    surName = 'surnameHere'
+                    mail = 'mailhere'
+                    userAccountControl = 66048
+                }
+            }
+
+            $results = Get-PoshSpecADUser -Name 'DoesExist'
+
+            it 'should return a single pscustomobject' {
+                @($results).Count | should be 1
+            }
+
+            it 'should return the expected name' {
+                $results.Name | should be 'namehere'
+            }
+
+            it 'should return the expected GivenName' {
+                $results.GivenName | should be 'givenNameHere'
+            }
+
+            it 'should return the expected SurName' {
+                $results.SurName | should be 'surNameHere'
+            }
+            
+            it 'should return the expected Mail property' {
+                $results.Mail | should be 'mailhere'
+            }
+
+            it 'should return the expected Enabled property' {
+                $results.Enabled | should be $true
+            }
+
+            it 'should return the expected PasswordNeverExpires property' {
+                $results.PasswordNeverExpires | should be $true
+            }
+
+            it 'should return the expected PasswordExpired property' {
+                $results.PasswordExpired | should be $false
+            }
+
+        }
+
+        context 'User does not exist' {
+            
+            mock 'SearchAd'
+
+            $results = Get-PoshSpecADUser -Name 'DoesNotExist'
+
+            it 'should return nothing' {
+                $results | should BeNullOrEmpty
+            }
+
+        }
+    }
 }
 
 Describe 'Test Functions' {
@@ -86,7 +294,7 @@ Describe 'Test Functions' {
             }
 
             It "Should return the correct test Expression" {
-                $results.Expression | Should Be "'C:\inetpub\wwwroot\iisstart.htm' | Should Exist"
+                $results.Expression | Should Be "Get-Item -Path 'C:\inetpub\wwwroot\iisstart.htm' -ErrorAction SilentlyContinue | should not benullorempty"
             }
         }
         
@@ -99,7 +307,7 @@ Describe 'Test Functions' {
             }
 
             It "Should return the correct test Expression" {
-                $results.Expression | Should Be "'HKLM:\SOFTWARE\Microsoft\Rpc\ClientProtocols' | Should Exist"
+                $results.Expression | Should Be "Get-Item -Path 'HKLM:\SOFTWARE\Microsoft\Rpc\ClientProtocols' -ErrorAction SilentlyContinue | should not benullorempty"
             }
         }
         
@@ -151,7 +359,7 @@ Describe 'Test Functions' {
             }
 
             It "Should return the correct test Expression" {
-                $results.Expression | Should Be "Get-HotFix -Id KB1234567 -ErrorAction SilentlyContinue | Should Exist"
+                $results.Expression | Should Be "Get-HotFix -Id KB1234567 -ErrorAction SilentlyContinue | should not benullorempty"
             }
         }
         
@@ -277,7 +485,7 @@ Describe 'Test Functions' {
             }
 
             It "Should return the correct test Expression" {
-                $results.Expression | Should Be "'C:\ProgramData' | Should Exist"
+                $results.Expression | Should Be "Get-Item -Path 'C:\ProgramData' -ErrorAction SilentlyContinue | should not benullorempty"
             }
         }
         
@@ -362,7 +570,7 @@ Describe 'Test Functions' {
             }
 
             It "Should return the correct test Expression" {
-                $results.Expression | Should Be "Get-ItemProperty -Path hklm:\\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object DisplayName -Match 'Microsoft .NET Framework 4.6.1' | Should Exist"
+                $results.Expression | Should Be "Get-ItemProperty -Path hklm:\\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object DisplayName -Match 'Microsoft .NET Framework 4.6.1' | should not benullorempty"
             }
         }
         


### PR DESCRIPTION
Added three AD object tests and also allowed all tests to use the ‘Should Exist’ assertion rather than just provider-specific objects. Also, if no property is provided, it defaults to the ‘Should Exist’ assertion.