### PR TITLE
Correct dependency handling

### DIFF
--- a/poshspec.psd1
+++ b/poshspec.psd1
@@ -51,7 +51,7 @@ PowerShellVersion = '3.0'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-# RequiredModules = @()
+RequiredModules = 'Pester'
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()

--- a/poshspec.psm1
+++ b/poshspec.psm1
@@ -1,12 +1,3 @@
-try 
-{
-    Import-Module Pester
-}
-catch [Exception]
-{
-    throw 'The Pester module is required to use this module.'
-}
-
 #Get public and private function definition files.
 $Public  = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -ErrorAction SilentlyContinue )
 $Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue )


### PR DESCRIPTION
The existing release improperly imports Pester in the PSM1 in an attempt to ensure the dependency is fulfilled.  This ends up impairing Pester's ability to be used on its own.  The correct way to do this is by adding Pester to the "RequiredModules" section of the module manifest ("poshspec.psd1")

I did not increment the version ID in the manifest.